### PR TITLE
Implement Deref and DerefMut for Rcc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - PWM output on complementary channels only for single channel timers (TIM16 + TIM17)
 - impl embedded_hal_1::spi::SpiBus for SPI
 - impl embedded_hal_1::digital traits for Pins
+- impl core::{Deref, DerefMut} for Rcc
 
 ### Fixed
 

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -1,5 +1,6 @@
 use crate::pac::RCC;
 use crate::time::Hertz;
+use core::ops::{Deref, DerefMut};
 
 /// Extension trait that sets up the `RCC` peripheral
 pub trait RccExt {
@@ -43,6 +44,20 @@ impl RccExt for RCC {
 pub struct Rcc {
     pub clocks: Clocks,
     pub(crate) regs: RCC,
+}
+
+impl Deref for Rcc {
+    type Target = RCC;
+
+    fn deref(&self) -> &Self::Target {
+        &self.regs
+    }
+}
+
+impl DerefMut for Rcc {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.regs
+    }
 }
 
 pub enum HSEBypassMode {


### PR DESCRIPTION
Cordoning off access to RCC registers makes implementing certain software and drivers (e.g. a bootloader for STMF0 cores need SYSCFG) unnecessarily difficult.

A completely encapsulated RCC renders peripheral enable registers inaccessible and some drivers (e.g stm32_usbd) opt for using unsafe raw pointer accesses completely eliminating the safety and the structure provided by the HAL.

This commit copies an escape hatch from stm32f4xx-hal crate by implementing Deref and DerefMut for Rcc structure. The stm32f4xx-hal implementation can be seen at the link below: https://github.com/stm32-rs/stm32f4xx-hal/blob/0ba01f4fb3f19b0eea40d8ea2403e2e9d4e41609/src/rcc/mod.rs#L56-L67